### PR TITLE
fix Makefile find usage for linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: all test tests j2me java certs app clean
-BASIC_SRCS=$(shell find . -name "*.ts" -d 1)
+BASIC_SRCS=$(shell find . -maxdepth 1 -name "*.ts")
 JIT_SRCS=$(shell find jit -name "*.ts")
 
 all: java tests j2me


### PR DESCRIPTION
This makes the Makefile work on linux. I don't know if OS X has `-maxdepth` though...

I also had to change the order of the arguments to avoid a warning.
