### PR TITLE
fix and optimize typed array loads in Frame

### DIFF
--- a/context.ts
+++ b/context.ts
@@ -46,22 +46,19 @@ module J2ME {
     }
 
     read32(): number {
-      return this.read16() << 16 | this.read16();
+      return this.read32signed() >>> 0;
     }
 
     read8signed(): number {
-      var x = this.read8();
-      return (x > 0x7f) ? (x - 0x100) : x;
+      return this.read8() << 24 >> 24;
     }
 
     read16signed(): number {
-      var x = this.read16();
-      return (x > 0x7fff) ? (x - 0x10000) : x;
+      return this.read16() << 16 >> 16;
     }
 
     read32signed(): number {
-      var x = this.read32();
-      return (x > 0x7fffffff) ? (x - 0x100000000) : x;
+      return this.read16() << 16 | this.read16();
     }
 
     /**


### PR DESCRIPTION
This fixes `read32()`, which was returning a signed value (output of `|` is always signed), and optimizes the other composed loads.

Is there a simple way to run scimark? I saw mention of it in some of the files, but I didn't see a way to run it.

Also, can you please remind me what I should run to test if this regresses anything?
