### PR TITLE
increase test timeout

### DIFF
--- a/tests/automation.js
+++ b/tests/automation.js
@@ -16,7 +16,7 @@ casper.on('remote.message', function(message) {
     this.echo(message);
 });
 
-casper.options.waitTimeout = 80000;
+casper.options.waitTimeout = 100000;
 casper.options.verbose = true;
 casper.options.viewportSize = { width: 240, height: 320 };
 casper.options.clientScripts = [


### PR DESCRIPTION
Tests take longer to run on the intex branch at the moment, so they frequently time out. This change increases the timeout to accommodate the additonal time it currently takes.
