### PR TITLE
warn on unsafe conversion from long to number

### DIFF
--- a/int.ts
+++ b/int.ts
@@ -57,7 +57,11 @@ module J2ME {
    * The closest floating-point representation to this long value.
    */
   export function longToNumber(l: number, h: number): number {
-    return h * Constants.TWO_PWR_32_DBL + ((l >= 0) ? l : Constants.TWO_PWR_32_DBL + l);
+    var n = h * Constants.TWO_PWR_32_DBL + ((l >= 0) ? l : Constants.TWO_PWR_32_DBL + l);
+    if (Math.abs(n) > Constants.NUMBER_MAX_SAFE_INTEGER) {
+      console.warn("unsafe conversion from long to number: " + h + "," + l);
+    }
+    return n;
   }
 
   export function numberToLong(v: number): number {

--- a/vm/runtime.ts
+++ b/vm/runtime.ts
@@ -1970,7 +1970,11 @@ module J2ME {
     LONG_MIN_HIGH = 0x80000000,
 
 
-    TWO_PWR_32_DBL = 4294967296
+    TWO_PWR_32_DBL = 4294967296,
+
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isSafeInteger
+    NUMBER_MAX_SAFE_INTEGER = Math.pow(2, 53) - 1,
   }
 
   export function monitorEnter(object: J2ME.java.lang.Object) {


### PR DESCRIPTION
This should help us identify unsafe conversions. Unsure if there's a perf implication here.
